### PR TITLE
patch android build -fPIC

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,11 @@
       "include_dirs" : [
           "<!(node -e \"require('nan')\")"
       ],
+      "conditions" : [
+	['OS=="android"', {
+	  "cflags_cc":["-fPIC"],
+	}],
+      ],
     }
   ]
 }


### PR DESCRIPTION
To build this package using npm through Termux on Android, requires -fPIC.